### PR TITLE
Temp Fix: First ever created Admin User unable to view Dashboard

### DIFF
--- a/src/Dashboard/DashboardViewCollapseHelper.php
+++ b/src/Dashboard/DashboardViewCollapseHelper.php
@@ -17,7 +17,7 @@ class DashboardViewCollapseHelper {
     {
     }
 
-    public function collapseView(DashboardView $view, Teacher|Student $teacherOrStudent): void {
+    public function collapseView(DashboardView $view, Teacher|Student|null $teacherOrStudent): void {
         foreach($view->getLessons() as $lesson) {
             $this->collapseLesson($lesson, $view, $teacherOrStudent);
         }


### PR DESCRIPTION
Wenn im idp nur ein erster Admin erstellt wird der kein Lehrer etc. ist kann dieser nicht auf das icc-Dashboard zugreifen. über die direkte Url die Einstellungen aufzurufen geht, nur kommt beim Login und der darauffolgenden Weiterleitung direkt folgender Fehler:

![Bildschirmfoto 2023-11-27 um 22 16 44](https://github.com/LoPablo/icc/assets/28061988/6113c612-56d3-498d-bda7-6823202737a7)

Der Commit unten behebt das, ist aber wahrscheinlich eher nur ein temporärer Fix.